### PR TITLE
ci(deps): auto-merge safe Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge for safe updates
+        if: |
+          steps.meta.outputs.package-ecosystem == 'github_actions' ||
+          (steps.meta.outputs.package-ecosystem == 'gomod' &&
+            (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+             steps.meta.outputs.update-type == 'version-update:semver-minor'))
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml`
- Approves and enables `--auto` merge for low-risk Dependabot PRs
- Branch protection (5 required checks: lint/test/build/security/docs) still gates every merge

## Scope
| Update | Auto-merge |
|--------|-----------|
| `github-actions` (any version) | yes — CI tooling, can't affect the released binary |
| `gomod` patch / minor | yes — tests gate it |
| `gomod` major | **no** — needs human review for SDK / plugin-framework breakage |

## How it works
1. PR opens, CI runs (lint, test, build, security, docs)
2. Workflow reads update metadata via `dependabot/fetch-metadata@v2` (pinned by SHA)
3. If safe category: auto-approves, then `gh pr merge --auto --squash --delete-branch`
4. GitHub waits for required checks before actually merging — no race

## Test plan
- [ ] Merge this PR
- [ ] Next Dependabot PR (weekly schedule) lands and exercises the workflow
- [ ] Verify gomod major bump (when one arrives) is left for manual review