### PR TITLE
fix: handle nested credentials object in cloud sync GET/list response

### DIFF
--- a/internal/client/cloud_sync.go
+++ b/internal/client/cloud_sync.go
@@ -23,6 +23,40 @@ type CloudSync struct {
 	Attributes   map[string]interface{} `json:"attributes,omitempty"`
 }
 
+// UnmarshalJSON handles the TrueNAS API returning credentials as either a plain
+// integer (on create/update responses) or a nested object {"id": N, ...} (on
+// get/list responses). The Go struct field is always stored as the integer ID.
+func (cs *CloudSync) UnmarshalJSON(data []byte) error {
+	type Alias CloudSync
+	aux := &struct {
+		Credentials json.RawMessage `json:"credentials"`
+		*Alias
+	}{
+		Alias: (*Alias)(cs),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.Credentials) == 0 {
+		return nil
+	}
+	// Try plain integer first (create/update responses).
+	var credID int
+	if err := json.Unmarshal(aux.Credentials, &credID); err == nil {
+		cs.Credentials = credID
+		return nil
+	}
+	// Fall back to nested object {"id": N, ...} (get/list responses).
+	var credObj struct {
+		ID int `json:"id"`
+	}
+	if err := json.Unmarshal(aux.Credentials, &credObj); err != nil {
+		return fmt.Errorf("credentials field: %w", err)
+	}
+	cs.Credentials = credObj.ID
+	return nil
+}
+
 // CloudSyncCreateRequest represents the request to create a cloud sync task.
 type CloudSyncCreateRequest struct {
 	Description  string                 `json:"description,omitempty"`

--- a/internal/client/cloud_sync_test.go
+++ b/internal/client/cloud_sync_test.go
@@ -50,6 +50,40 @@ func TestCloudSync_CRUD(t *testing.T) {
 		}
 	})
 
+	t.Run("Get with nested credentials object (import/read path)", func(t *testing.T) {
+		// TrueNAS returns credentials as a full object on GET/list, not a plain int.
+		// This shape previously caused: "cannot unmarshal object into Go struct field
+		// CloudSync.credentials of type int".
+		_, c := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{
+				"id": 2,
+				"description": "Google Drive - Max",
+				"path": "/mnt/Data/backup/max_google-drive",
+				"credentials": {
+					"id": 2,
+					"name": "Google Drive",
+					"provider": {"type": "GOOGLE_DRIVE"}
+				},
+				"direction": "PULL",
+				"transfer_mode": "SYNC",
+				"schedule": {"minute": "0", "hour": "0", "dom": "*", "month": "*", "dow": "*"},
+				"enabled": true,
+				"attributes": {"folder": "/", "fast_list": false, "acknowledge_abuse": false}
+			}`))
+		}))
+
+		got, err := c.GetCloudSync(ctx, 2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Credentials != 2 {
+			t.Errorf("Credentials = %d, want 2", got.Credentials)
+		}
+		if got.Description != "Google Drive - Max" {
+			t.Errorf("Description = %q", got.Description)
+		}
+	})
+
 	t.Run("Get 404", func(t *testing.T) {
 		_, c := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"message": "nope"})


### PR DESCRIPTION
## Problem

`terraform import truenas_cloud_sync.*` fails with:

```
json: cannot unmarshal object into Go struct field CloudSync.credentials of type int
```

The TrueNAS REST API returns `credentials` as a **full nested object** on `GET /cloudsync/id/<n>` and `GET /cloudsync`:

```json
{
  "credentials": {
    "id": 2,
    "name": "Google Drive",
    "provider": { "type": "GOOGLE_DRIVE" }
  }
}
```

But on `POST /cloudsync` (create) and `PUT /cloudsync/id/<n>` (update) it returns a **plain integer**:

```json
{ "credentials": 2 }
```

The `CloudSync` struct has `Credentials int`, so `json.Unmarshal` fails whenever it receives the object shape — which is every read/import path.

## Fix

Add a custom `UnmarshalJSON` on `CloudSync` using the type alias pattern to handle both shapes:

- Plain `int` → use directly (create/update responses)
- Nested object `{"id": N, ...}` → extract `.id` (get/list responses)

The `Alias` type alias breaks the recursion so the rest of the struct still unmarshals normally.

## Test

Added `TestCloudSync_CRUD/"Get with nested credentials object (import/read path)"` that reproduces the exact JSON shape the TrueNAS API sends on GET and verifies `Credentials` is correctly extracted as an integer ID.

## Impact

- Fixes `terraform import truenas_cloud_sync.*` (previously always errored)
- Fixes `terraform refresh` / `terraform plan` for existing cloud sync tasks
- No change to create/update behaviour