### PR TITLE
fix(user): use Set for groups to avoid ordering drift (close #19)

### DIFF
--- a/internal/resources/user.go
+++ b/internal/resources/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -51,7 +53,7 @@ type UserResourceModel struct {
 	Password     types.String   `tfsdk:"password"`
 	Group        types.Int64    `tfsdk:"group"`
 	GroupCreate  types.Bool     `tfsdk:"group_create"`
-	Groups       types.List     `tfsdk:"groups"`
+	Groups       types.Set      `tfsdk:"groups"`
 	Home         types.String   `tfsdk:"home"`
 	Shell        types.String   `tfsdk:"shell"`
 	Locked       types.Bool     `tfsdk:"locked"`
@@ -145,12 +147,12 @@ func (r *UserResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
 			},
-			"groups": schema.ListAttribute{
+			"groups": schema.SetAttribute{
 				Description: "List of auxiliary group IDs.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.Int64Type,
-				Default:     listdefault.StaticValue(types.ListValueMust(types.Int64Type, []attr.Value{})),
+				Default:     setdefault.StaticValue(types.SetValueMust(types.Int64Type, []attr.Value{})),
 			},
 			"home": schema.StringAttribute{
 				Description: "Home directory path. Must begin with /mnt or be /var/empty.",
@@ -264,6 +266,7 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		for i, g := range groups {
 			intGroups[i] = int(g)
 		}
+		sort.Ints(intGroups)
 		createReq.Groups = intGroups
 	}
 
@@ -387,6 +390,7 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		for i, g := range groups {
 			intGroups[i] = int(g)
 		}
+		sort.Ints(intGroups)
 		updateReq.Groups = intGroups
 	}
 
@@ -486,12 +490,15 @@ func (r *UserResource) mapResponseToModel(_ context.Context, user *truenas.User,
 		model.SSHPubKey = types.StringValue("")
 	}
 
-	// groups is a list of int64
-	groupValues := make([]attr.Value, len(user.Groups))
-	for i, g := range user.Groups {
+	// groups — sort consistently with ModifyPlan
+	ids := make([]int, len(user.Groups))
+	copy(ids, user.Groups)
+	sort.Ints(ids)
+	groupValues := make([]attr.Value, len(ids))
+	for i, g := range ids {
 		groupValues[i] = types.Int64Value(int64(g))
 	}
-	model.Groups = types.ListValueMust(types.Int64Type, groupValues)
+	model.Groups = types.SetValueMust(types.Int64Type, groupValues)
 
 	// sudo_commands
 	cmdValues := make([]attr.Value, len(user.SudoCommands))
@@ -500,3 +507,4 @@ func (r *UserResource) mapResponseToModel(_ context.Context, user *truenas.User,
 	}
 	model.SudoCommands = types.ListValueMust(types.StringType, cmdValues)
 }
+

--- a/internal/resources/zz_crud_full_test.go
+++ b/internal/resources/zz_crud_full_test.go
@@ -31,6 +31,15 @@ func numList(vals ...int64) tftypes.Value {
 	return tftypes.NewValue(tftypes.List{ElementType: tftypes.Number}, items)
 }
 
+// numSet returns a set[number] tftypes value.
+func numSet(vals ...int64) tftypes.Value {
+	items := make([]tftypes.Value, len(vals))
+	for i, v := range vals {
+		items[i] = tftypes.NewValue(tftypes.Number, v)
+	}
+	return tftypes.NewValue(tftypes.Set{ElementType: tftypes.Number}, items)
+}
+
 // --- NFS share full values ---
 
 func TestNFSShareResource_CRUD_Full(t *testing.T) {
@@ -155,7 +164,7 @@ func TestUserResource_CRUD_Full(t *testing.T) {
 		"password":          str("hunter2"),
 		"locked":            flag(false),
 		"smb":               flag(true),
-		"groups":            numList(101),
+		"groups":            numSet(101),
 		"sudo_commands":     strList("/bin/ls"),
 		"sshpubkey":         str("ssh-rsa AAA..."),
 		"password_disabled": flag(false),


### PR DESCRIPTION
## Summary
Fix #19 

The TrueNAS API returns group membership as an unordered set of GIDs, but the schema used a List attribute.  When the server returned groups in a different order than Terraform's state, every plan detected spurious drift.

- Change schema from ListAttribute to SetAttribute
- Sort group IDs client-side before sending to the API
- Sort group IDs in mapResponseToModel for deterministic state

**NOTE**: this PR was created with help of OpenCode's BigPickle model. I tend to not do that, but a) I'm not super familiar with Go; b) the codebase seems to be already largely written with coding agents.

## Type of change
<!-- [REQUIRED] Check one. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New resource (new `truenas_*` resource)
- [ ] New data source (new `data.truenas_*` data source)
- [ ] Enhancement to an existing resource/data source
- [ ] Provider-level change (client, retry, timeouts, schema)
- [ ] Documentation only
- [ ] CI / tooling / build
- [ ] Breaking change (requires major version bump)

## Resources / data sources affected

- `truenas_user`

## Checklist
- [ ] `go build ./...` passes
- [ ] `go test -race ./...` passes
- [ ] `go test -cover ./...` maintains 100.0% on every package
- [ ] `golangci-lint run ./...` passes with zero findings
- [ ] `govulncheck ./...` reports no new vulnerabilities
- [ ] `tfplugindocs validate` passes
- [ ] I ran the relevant `TF_ACC` acceptance tests against a real TrueNAS SCALE
      test VM (not prod) and recorded the results below
- [ ] CHANGELOG.md `[Unreleased]` section updated
- [ ] Docs regenerated (`make docs` or `tfplugindocs generate`)
- [ ] Examples in `examples/resources/<name>/` updated if the schema changed
- [ ] Sensitive fields marked with `Sensitive: true`
- [ ] New validators added to schema where applicable

