### PR TITLE
fix(directory): preserve uid/gid after setperm to avoid stale stat (f…

### DIFF
--- a/internal/resources/directory.go
+++ b/internal/resources/directory.go
@@ -203,7 +203,17 @@ func (r *DirectoryResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	// setperm completed SUCCESS; trust our applied uid/gid over
+	// potentially stale stat data (TrueNAS caching).
+	uid := plan.UID
+	gid := plan.GID
 	r.mapStatToModel(stat, &plan)
+	if !uid.IsNull() && !uid.IsUnknown() {
+		plan.UID = uid
+	}
+	if !gid.IsNull() && !gid.IsUnknown() {
+		plan.GID = gid
+	}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -269,7 +279,17 @@ func (r *DirectoryResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
+	// setperm completed SUCCESS; trust our applied uid/gid over
+	// potentially stale stat data (TrueNAS caching).
+	uid := plan.UID
+	gid := plan.GID
 	r.mapStatToModel(stat, &plan)
+	if !uid.IsNull() && !uid.IsUnknown() {
+		plan.UID = uid
+	}
+	if !gid.IsNull() && !gid.IsUnknown() {
+		plan.GID = gid
+	}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
## Summary

Fix #21

`filesystem.setperm` runs as a job that completes successfully, but the subsequent filesystem.stat call may return stale data (e.g. gid=0) due to TrueNAS caching/propagation delay.  Override stat results with the planned uid/gid values after a successful setperm.

**NOTE 1**: this PR was created with help of OpenCode's BigPickle model. I tend to not do that, but a) I'm not super familiar with Go; b) the codebase seems to be already largely written with coding agents.

**NOTE 2**: this is a partial fix. We still have the drift, but at least it doesn't interrupt the provision.

## Type of change
<!-- [REQUIRED] Check one. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New resource (new `truenas_*` resource)
- [ ] New data source (new `data.truenas_*` data source)
- [ ] Enhancement to an existing resource/data source
- [ ] Provider-level change (client, retry, timeouts, schema)
- [ ] Documentation only
- [ ] CI / tooling / build
- [ ] Breaking change (requires major version bump)

## Resources / data sources affected

- `truenas_directory`

## Checklist
- [ ] `go build ./...` passes
- [ ] `go test -race ./...` passes
- [ ] `go test -cover ./...` maintains 100.0% on every package
- [ ] `golangci-lint run ./...` passes with zero findings
- [ ] `govulncheck ./...` reports no new vulnerabilities
- [ ] `tfplugindocs validate` passes
- [ ] I ran the relevant `TF_ACC` acceptance tests against a real TrueNAS SCALE
      test VM (not prod) and recorded the results below
- [ ] CHANGELOG.md `[Unreleased]` section updated
- [ ] Docs regenerated (`make docs` or `tfplugindocs generate`)
- [ ] Examples in `examples/resources/<name>/` updated if the schema changed
- [ ] Sensitive fields marked with `Sensitive: true`
- [ ] New validators added to schema where applicable


## Related issues

- #14 
