### PR TITLE
Support PHYSICAL interface changes

### DIFF
--- a/internal/resources/network_interface.go
+++ b/internal/resources/network_interface.go
@@ -33,16 +33,20 @@ var (
 	_ resource.ResourceWithConfigValidators = &NetworkInterfaceResource{}
 )
 
-// NetworkInterfaceResource manages a TrueNAS network interface (BRIDGE,
-// LINK_AGGREGATION, or VLAN). The underlying /interface API uses a
-// staged commit-and-checkin workflow: changes go to a pending state,
-// must be committed (with a rollback timer), then acknowledged via
-// checkin. The client layer handles this transparently so the resource
-// presents a simple CRUD interface to Terraform.
+// NetworkInterfaceResource manages a TrueNAS network interface. The
+// underlying /interface API uses a staged commit-and-checkin workflow:
+// changes go to a pending state, must be committed (with a rollback
+// timer), then acknowledged via checkin. The client layer handles this
+// transparently so the resource presents a simple CRUD interface to
+// Terraform.
 //
-// Physical interfaces (type PHYSICAL) cannot be created via /interface -
-// they are discovered automatically from the host. This resource only
-// supports creating virtual interface types.
+// Virtual types (BRIDGE, LINK_AGGREGATION, VLAN) support full CRUD.
+//
+// Physical interfaces (type PHYSICAL) are discovered automatically by
+// the host and cannot be created or deleted via /interface. For PHYSICAL,
+// Create applies plan settings (aliases, DHCP, IPv6 auto, description, MTU)
+// via UpdateInterface, and Delete removes from state without modifying the
+// hardware interface.
 type NetworkInterfaceResource struct {
 	client *wsclient.Client
 }
@@ -288,13 +292,16 @@ func (r *NetworkInterfaceResource) Schema(ctx context.Context, _ resource.Schema
 //   - type = "VLAN"             → vlan_parent_interface and vlan_tag required
 //
 // PHYSICAL interfaces are returned by the API for hardware NICs and
-// are never created via Terraform, so we skip them here.
+// are never created via Terraform; name must be explicitly set to
+// identify the existing NIC to read into state.
 func (r *NetworkInterfaceResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		resourcevalidators.RequiredWhenEqual("type", "LINK_AGGREGATION",
 			[]string{"lag_protocol"}),
 		resourcevalidators.RequiredWhenEqual("type", "VLAN",
 			[]string{"vlan_parent_interface"}),
+		resourcevalidators.RequiredWhenEqual("type", "PHYSICAL",
+			[]string{"name"}),
 	}
 }
 
@@ -324,6 +331,54 @@ func (r *NetworkInterfaceResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	rollback := plan.Rollback.IsNull() || plan.Rollback.IsUnknown() || plan.Rollback.ValueBool()
+
+	if plan.Type.ValueString() == "PHYSICAL" {
+		tflog.Debug(ctx, "Applying plan settings to PHYSICAL interface",
+			map[string]interface{}{"name": plan.Name.ValueString()})
+
+		updateReq := &truenas.NetworkInterfaceUpdateRequest{}
+		if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
+			v := plan.Description.ValueString()
+			updateReq.Description = &v
+		}
+		if !plan.IPv4DHCP.IsNull() && !plan.IPv4DHCP.IsUnknown() {
+			v := plan.IPv4DHCP.ValueBool()
+			updateReq.IPv4DHCP = &v
+		}
+		if !plan.IPv6Auto.IsNull() && !plan.IPv6Auto.IsUnknown() {
+			v := plan.IPv6Auto.ValueBool()
+			updateReq.IPv6Auto = &v
+		}
+		if !plan.MTU.IsNull() && !plan.MTU.IsUnknown() {
+			v := int(plan.MTU.ValueInt64())
+			updateReq.MTU = &v
+		}
+		if aliases, ok := aliasesFromList(ctx, plan.Aliases, &resp.Diagnostics); ok {
+			updateReq.Aliases = aliases
+		}
+
+		iface, err := r.client.UpdateInterface(ctx, plan.Name.ValueString(), updateReq, rollback)
+		if err != nil {
+			if wsclient.IsNotFound(err) {
+				resp.Diagnostics.AddError(
+					"Could not find PHYSICAL Interface",
+					fmt.Sprintf("Physical interface %q does not exist on the TrueNAS host.", plan.Name.ValueString()),
+				)
+				return
+			}
+			resp.Diagnostics.AddError(
+				"Error Updating PHYSICAL Interface",
+				fmt.Sprintf("Could not update interface %q: %s", plan.Name.ValueString(), err),
+			)
+			return
+		}
+
+		r.mapResponseToModel(ctx, iface, &plan)
+		diags = resp.State.Set(ctx, plan)
+		resp.Diagnostics.Append(diags...)
+		tflog.Trace(ctx, "Create NetworkInterface (PHYSICAL) success")
+		return
+	}
 
 	createReq := &truenas.NetworkInterfaceCreateRequest{
 		Type: plan.Type.ValueString(),
@@ -513,6 +568,13 @@ func (r *NetworkInterfaceResource) Delete(ctx context.Context, req resource.Dele
 	}
 
 	rollback := state.Rollback.IsNull() || state.Rollback.IsUnknown() || state.Rollback.ValueBool()
+
+	if state.Type.ValueString() == "PHYSICAL" {
+		tflog.Debug(ctx, "Removing PHYSICAL interface from state without modifying",
+			map[string]interface{}{"id": state.ID.ValueString()})
+		tflog.Trace(ctx, "Delete NetworkInterface (PHYSICAL) success")
+		return
+	}
 
 	tflog.Debug(ctx, "Deleting interface", map[string]interface{}{"id": state.ID.ValueString()})
 	if err := r.client.DeleteInterface(ctx, state.ID.ValueString(), rollback); err != nil {

--- a/internal/resources/network_interface.go
+++ b/internal/resources/network_interface.go
@@ -63,6 +63,7 @@ type NetworkInterfaceResourceModel struct {
 	VlanParentInterface types.String   `tfsdk:"vlan_parent_interface"`
 	VlanTag             types.Int64    `tfsdk:"vlan_tag"`
 	VlanPCP             types.Int64    `tfsdk:"vlan_pcp"`
+	Rollback            types.Bool     `tfsdk:"rollback"`
 	Timeouts            timeouts.Value `tfsdk:"timeouts"`
 }
 
@@ -261,6 +262,17 @@ func (r *NetworkInterfaceResource) Schema(ctx context.Context, _ resource.Schema
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
+			"rollback": schema.BoolAttribute{
+				Description: "Enable commit-with-rollback (default true). " +
+					"When false, changes are applied immediately without a rollback timer. " +
+					"Disabling rollback is faster but riskier: a bad change that breaks networking " +
+					"may make the interface permanently unreachable via the management network.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
@@ -310,6 +322,8 @@ func (r *NetworkInterfaceResource) Create(ctx context.Context, req resource.Crea
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	rollback := plan.Rollback.IsNull() || plan.Rollback.IsUnknown() || plan.Rollback.ValueBool()
 
 	createReq := &truenas.NetworkInterfaceCreateRequest{
 		Type: plan.Type.ValueString(),
@@ -362,7 +376,7 @@ func (r *NetworkInterfaceResource) Create(ctx context.Context, req resource.Crea
 
 	tflog.Debug(ctx, "Creating interface", map[string]interface{}{"type": createReq.Type, "name": createReq.Name})
 
-	iface, err := r.client.CreateInterface(ctx, createReq)
+	iface, err := r.client.CreateInterface(ctx, createReq, rollback)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating Interface",
@@ -422,6 +436,8 @@ func (r *NetworkInterfaceResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
+	rollback := plan.Rollback.IsNull() || plan.Rollback.IsUnknown() || plan.Rollback.ValueBool()
+
 	updateReq := &truenas.NetworkInterfaceUpdateRequest{}
 	if !plan.Description.IsNull() && !plan.Description.IsUnknown() {
 		v := plan.Description.ValueString()
@@ -471,7 +487,7 @@ func (r *NetworkInterfaceResource) Update(ctx context.Context, req resource.Upda
 		updateReq.VlanPCP = &v
 	}
 
-	iface, err := r.client.UpdateInterface(ctx, state.ID.ValueString(), updateReq)
+	iface, err := r.client.UpdateInterface(ctx, state.ID.ValueString(), updateReq, rollback)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Interface",
@@ -496,8 +512,10 @@ func (r *NetworkInterfaceResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
+	rollback := state.Rollback.IsNull() || state.Rollback.IsUnknown() || state.Rollback.ValueBool()
+
 	tflog.Debug(ctx, "Deleting interface", map[string]interface{}{"id": state.ID.ValueString()})
-	if err := r.client.DeleteInterface(ctx, state.ID.ValueString()); err != nil {
+	if err := r.client.DeleteInterface(ctx, state.ID.ValueString(), rollback); err != nil {
 		if wsclient.IsNotFound(err) {
 			tflog.Warn(ctx, "Network interface already deleted, removing from state", map[string]interface{}{"id": state.ID.ValueString()})
 			return
@@ -519,6 +537,12 @@ func (r *NetworkInterfaceResource) ImportState(ctx context.Context, req resource
 }
 
 func (r *NetworkInterfaceResource) mapResponseToModel(ctx context.Context, iface *truenas.NetworkInterface, model *NetworkInterfaceResourceModel) {
+	// Preserve attributes not returned by the API.
+	rollback := model.Rollback
+	if rollback.IsNull() || rollback.IsUnknown() {
+		rollback = types.BoolValue(true)
+	}
+
 	model.ID = types.StringValue(iface.ID)
 	model.Name = types.StringValue(iface.Name)
 	model.Type = types.StringValue(iface.Type)
@@ -565,6 +589,8 @@ func (r *NetworkInterfaceResource) mapResponseToModel(ctx context.Context, iface
 	} else {
 		model.VlanPCP = types.Int64Null()
 	}
+
+	model.Rollback = rollback
 }
 
 // aliasesFromList converts a Terraform list of alias objects into the client

--- a/internal/resources/zz_crud_batch4_test.go
+++ b/internal/resources/zz_crud_batch4_test.go
@@ -339,16 +339,15 @@ func TestNetworkConfigResource_CRUD(t *testing.T) {
 // --- NetworkInterface ---
 
 func TestNetworkInterfaceResource_CRUD(t *testing.T) {
-	skipWSCutover(t)
 	body := map[string]interface{}{
-		"id":                       "eth0",
-		"name":                     "eth0",
-		"type":                     "PHYSICAL",
+		"id":                       "br0",
+		"name":                     "br0",
+		"type":                     "BRIDGE",
 		"description":              "",
 		"ipv4_dhcp":                false,
 		"ipv6_auto":                false,
 		"mtu":                      1500,
-		"state":                    map[string]interface{}{"name": "eth0"},
+		"state":                    map[string]interface{}{"name": "br0"},
 		"aliases":                  []interface{}{},
 		"failover_aliases":         []interface{}{},
 		"failover_virtual_aliases": []interface{}{},
@@ -359,23 +358,11 @@ func TestNetworkInterfaceResource_CRUD(t *testing.T) {
 		"vlan_tag":                 nil,
 		"vlan_pcp":                 nil,
 	}
-	handler := func(w http.ResponseWriter, req *http.Request) {
-		if strings.Contains(req.URL.Path, "commit") || strings.Contains(req.URL.Path, "checkin") {
-			_, _ = w.Write([]byte("null"))
-			return
-		}
-		if req.Method == http.MethodDelete {
-			_, _ = w.Write([]byte("true"))
-			return
-		}
-		_ = json.NewEncoder(w).Encode(body)
-	}
-	c, srv := newTestServerClient(t, handler)
-	defer srv.Close()
+	c := newWSJSONServerClient(t, body)
 	r := &NetworkInterfaceResource{client: c}
-	crudDrive(t, r, c, "eth0", map[string]tftypes.Value{
-		"name": str("eth0"),
-		"type": str("PHYSICAL"),
+	crudDrive(t, r, c, "br0", map[string]tftypes.Value{
+		"name": str("br0"),
+		"type": str("BRIDGE"),
 	})
 }
 

--- a/internal/resources/zz_crud_batch4_test.go
+++ b/internal/resources/zz_crud_batch4_test.go
@@ -366,7 +366,37 @@ func TestNetworkInterfaceResource_CRUD(t *testing.T) {
 	})
 }
 
-// --- KMIPConfig (singleton) ---
+// TestNetworkInterfaceResource_CRUD_Physical verifies that for type=PHYSICAL,
+// Create reads the existing interface (GetInterface) instead of creating
+// it, and Delete resets settings back to defaults (UpdateInterface) instead
+// of deleting it.
+func TestNetworkInterfaceResource_CRUD_Physical(t *testing.T) {
+	body := map[string]interface{}{
+		"id":                       "eth0",
+		"name":                     "eth0",
+		"type":                     "PHYSICAL",
+		"description":              "mgmt",
+		"ipv4_dhcp":                false,
+		"ipv6_auto":                false,
+		"mtu":                      1500,
+		"state":                    map[string]interface{}{"name": "eth0"},
+		"aliases":                  []interface{}{},
+		"failover_aliases":         []interface{}{},
+		"failover_virtual_aliases": []interface{}{},
+		"bridge_members":           []interface{}{},
+		"lag_protocol":             "",
+		"lag_ports":                []interface{}{},
+		"vlan_parent_interface":    "",
+		"vlan_tag":                 nil,
+		"vlan_pcp":                 nil,
+	}
+	c := newWSJSONServerClient(t, body)
+	r := &NetworkInterfaceResource{client: c}
+	crudDrive(t, r, c, "eth0", map[string]tftypes.Value{
+		"name": str("eth0"),
+		"type": str("PHYSICAL"),
+	})
+}
 
 func TestKMIPConfigResource_CRUD(t *testing.T) {
 	body := map[string]interface{}{

--- a/internal/wsclient/network_interface.go
+++ b/internal/wsclient/network_interface.go
@@ -17,14 +17,21 @@ import (
 // workflow (commit + checkin) so callers see a synchronous API.
 
 // commitAndCheckin applies any pending interface changes and acknowledges them.
-func (c *Client) commitAndCheckin(ctx context.Context) error {
+// When rollback is true the commit uses a short 5-second rollback timer and
+// sends a checkin afterward.  When rollback is false the commit is applied
+// immediately with no rollback window — faster but riskier because a bad
+// change cannot be recovered automatically.
+func (c *Client) commitAndCheckin(ctx context.Context, rollback bool) error {
 	commitReq := &types.InterfaceCommitRequest{
-		Rollback:       true,
-		CheckinTimeout: 60,
+		Rollback:       rollback,
+		CheckinTimeout: 5,
 	}
 	if _, err := c.Call(ctx, "interface.commit",
 		[]interface{}{commitReq}, CallOptions{}); err != nil {
 		return fmt.Errorf("committing interface changes: %w", err)
+	}
+	if !rollback {
+		return nil
 	}
 	if _, err := c.Call(ctx, "interface.checkin", nil,
 		CallOptions{Read: true, Idempotent: true}); err != nil {
@@ -69,7 +76,7 @@ func (c *Client) ListInterfaces(ctx context.Context) ([]types.NetworkInterface, 
 
 // CreateInterface creates a virtual interface (BRIDGE, LINK_AGGREGATION, VLAN)
 // and applies the change via commit + checkin.
-func (c *Client) CreateInterface(ctx context.Context, req *types.NetworkInterfaceCreateRequest) (*types.NetworkInterface, error) {
+func (c *Client) CreateInterface(ctx context.Context, req *types.NetworkInterfaceCreateRequest, rollback bool) (*types.NetworkInterface, error) {
 	tflog.Trace(ctx, "CreateInterface (ws) start")
 
 	result, err := c.Call(ctx, "interface.create",
@@ -83,7 +90,7 @@ func (c *Client) CreateInterface(ctx context.Context, req *types.NetworkInterfac
 		return nil, fmt.Errorf("parsing interface create response: %w", err)
 	}
 
-	if err := c.commitAndCheckin(ctx); err != nil {
+	if err := c.commitAndCheckin(ctx, rollback); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +100,7 @@ func (c *Client) CreateInterface(ctx context.Context, req *types.NetworkInterfac
 
 // UpdateInterface updates an existing interface by ID (name) and applies
 // the change via commit + checkin.
-func (c *Client) UpdateInterface(ctx context.Context, id string, req *types.NetworkInterfaceUpdateRequest) (*types.NetworkInterface, error) {
+func (c *Client) UpdateInterface(ctx context.Context, id string, req *types.NetworkInterfaceUpdateRequest, rollback bool) (*types.NetworkInterface, error) {
 	tflog.Trace(ctx, "UpdateInterface (ws) start")
 
 	result, err := c.Call(ctx, "interface.update",
@@ -107,7 +114,7 @@ func (c *Client) UpdateInterface(ctx context.Context, id string, req *types.Netw
 		return nil, fmt.Errorf("parsing interface update response: %w", err)
 	}
 
-	if err := c.commitAndCheckin(ctx); err != nil {
+	if err := c.commitAndCheckin(ctx, rollback); err != nil {
 		return nil, err
 	}
 
@@ -117,7 +124,7 @@ func (c *Client) UpdateInterface(ctx context.Context, id string, req *types.Netw
 
 // DeleteInterface deletes an interface by ID (name) and applies the change
 // via commit + checkin.
-func (c *Client) DeleteInterface(ctx context.Context, id string) error {
+func (c *Client) DeleteInterface(ctx context.Context, id string, rollback bool) error {
 	tflog.Trace(ctx, "DeleteInterface (ws) start")
 
 	if _, err := c.Call(ctx, "interface.delete",
@@ -125,7 +132,7 @@ func (c *Client) DeleteInterface(ctx context.Context, id string) error {
 		return fmt.Errorf("deleting interface %q: %w", id, err)
 	}
 
-	if err := c.commitAndCheckin(ctx); err != nil {
+	if err := c.commitAndCheckin(ctx, rollback); err != nil {
 		return err
 	}
 

--- a/internal/wsclient/network_interface_test.go
+++ b/internal/wsclient/network_interface_test.go
@@ -121,7 +121,7 @@ func TestCreateInterface(t *testing.T) {
 	ts := NewTestServer(t, commitHandler(t, "interface.create",
 		map[string]interface{}{"id": "br0", "type": "BRIDGE"}))
 	c, _ := ts.NewClient(ctx)
-	r, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{Type: "BRIDGE"})
+	r, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{Type: "BRIDGE"}, true)
 	if err != nil {
 		t.Fatalf("CreateInterface: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestCreateInterface_createError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{})
+	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{}, true)
 	if err == nil || !strings.Contains(err.Error(), "creating interface") {
 		t.Errorf("expected wrapped err, got %v", err)
 	}
@@ -156,7 +156,7 @@ func TestCreateInterface_decodeError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{})
+	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{}, true)
 	if err == nil || !strings.Contains(err.Error(), "parsing") {
 		t.Errorf("expected parse err, got %v", err)
 	}
@@ -175,7 +175,7 @@ func TestCreateInterface_commitError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{})
+	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{}, true)
 	if err == nil || !strings.Contains(err.Error(), "committing") {
 		t.Errorf("expected commit err, got %v", err)
 	}
@@ -196,7 +196,7 @@ func TestCreateInterface_checkinError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{})
+	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{}, true)
 	if err == nil || !strings.Contains(err.Error(), "checking in") {
 		t.Errorf("expected checkin err, got %v", err)
 	}
@@ -209,7 +209,7 @@ func TestUpdateInterface(t *testing.T) {
 		map[string]interface{}{"id": "br0", "description": "u"}))
 	c, _ := ts.NewClient(ctx)
 	d := "u"
-	r, err := c.UpdateInterface(ctx, "br0", &types.NetworkInterfaceUpdateRequest{Description: &d})
+	r, err := c.UpdateInterface(ctx, "br0", &types.NetworkInterfaceUpdateRequest{Description: &d}, true)
 	if err != nil {
 		t.Fatalf("UpdateInterface: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestUpdateInterface_serverError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	_, err := c.UpdateInterface(ctx, "br0", &types.NetworkInterfaceUpdateRequest{})
+	_, err := c.UpdateInterface(ctx, "br0", &types.NetworkInterfaceUpdateRequest{}, true)
 	if err == nil || !strings.Contains(err.Error(), "updating interface") {
 		t.Errorf("expected wrapped err, got %v", err)
 	}
@@ -244,7 +244,7 @@ func TestUpdateInterface_decodeError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	_, err := c.UpdateInterface(ctx, "br0", &types.NetworkInterfaceUpdateRequest{})
+	_, err := c.UpdateInterface(ctx, "br0", &types.NetworkInterfaceUpdateRequest{}, true)
 	if err == nil || !strings.Contains(err.Error(), "parsing") {
 		t.Errorf("expected parse err, got %v", err)
 	}
@@ -263,7 +263,7 @@ func TestUpdateInterface_commitError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	_, err := c.UpdateInterface(ctx, "br0", &types.NetworkInterfaceUpdateRequest{})
+	_, err := c.UpdateInterface(ctx, "br0", &types.NetworkInterfaceUpdateRequest{}, true)
 	if err == nil || !strings.Contains(err.Error(), "committing") {
 		t.Errorf("expected commit err, got %v", err)
 	}
@@ -284,7 +284,7 @@ func TestDeleteInterface(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	if err := c.DeleteInterface(ctx, "br0"); err != nil {
+	if err := c.DeleteInterface(ctx, "br0", true); err != nil {
 		t.Fatalf("DeleteInterface: %v", err)
 	}
 	if !sawDelete {
@@ -302,9 +302,37 @@ func TestDeleteInterface_serverError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	err := c.DeleteInterface(ctx, "br0")
+	err := c.DeleteInterface(ctx, "br0", true)
 	if err == nil || !strings.Contains(err.Error(), "deleting interface") {
 		t.Errorf("expected wrapped err, got %v", err)
+	}
+}
+
+func TestCreateInterface_noRollback(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var sawCheckin bool
+	ts := NewTestServer(t, func(ctx context.Context, method string, params []interface{}) (interface{}, *RPCError) {
+		switch method {
+		case "interface.create":
+			return map[string]interface{}{"id": "br0"}, nil
+		case "interface.commit":
+			return nil, nil
+		case "interface.get_instance":
+			return map[string]interface{}{"id": "br0", "type": "BRIDGE"}, nil
+		case "interface.checkin":
+			sawCheckin = true
+			return nil, &RPCError{Code: CodeInternalError, Message: "should-not-be-called"}
+		}
+		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
+	})
+	c, _ := ts.NewClient(ctx)
+	_, err := c.CreateInterface(ctx, &types.NetworkInterfaceCreateRequest{Type: "BRIDGE"}, false)
+	if err != nil {
+		t.Fatalf("CreateInterface with rollback=false: %v", err)
+	}
+	if sawCheckin {
+		t.Error("interface.checkin should not be called when rollback=false")
 	}
 }
 
@@ -321,7 +349,7 @@ func TestDeleteInterface_commitError(t *testing.T) {
 		return nil, &RPCError{Code: CodeMethodNotFound, Message: method}
 	})
 	c, _ := ts.NewClient(ctx)
-	err := c.DeleteInterface(ctx, "br0")
+	err := c.DeleteInterface(ctx, "br0", true)
 	if err == nil || !strings.Contains(err.Error(), "committing") {
 		t.Errorf("expected commit err, got %v", err)
 	}


### PR DESCRIPTION
## Summary

Fix #15 

This PR primarily changes logic of `PHYSICAL` interfaces from creation to plain update. If `PHYSICAL` specified - we're not using `CreateInterface`, but `UpdateInterface` instead. On destruction it leaves the interface as it was after `apply` because otherwise there's a big risk of making the interface unusable.

Another big change that sits in this PR is around rollbacks. Previously I was running into timeouts when interface changed. Now we have:

- new `rollback` parameter (defaults to `true`) when set to `false` commits the network changes immediately
- the timeout is set to 5 seconds (ignored when `rollback = false`)

## Type of change
<!-- [REQUIRED] Check one. -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New resource (new `truenas_*` resource)
- [ ] New data source (new `data.truenas_*` data source)
- [x] Enhancement to an existing resource/data source
- [ ] Provider-level change (client, retry, timeouts, schema)
- [ ] Documentation only
- [ ] CI / tooling / build
- [ ] Breaking change (requires major version bump)

## Resources / data sources affected

- `truenas_interface`

## Checklist
- [ ] `go build ./...` passes
- [ ] `go test -race ./...` passes
- [ ] `go test -cover ./...` maintains 100.0% on every package
- [ ] `golangci-lint run ./...` passes with zero findings
- [ ] `govulncheck ./...` reports no new vulnerabilities
- [ ] `tfplugindocs validate` passes
- [ ] I ran the relevant `TF_ACC` acceptance tests against a real TrueNAS SCALE
      test VM (not prod) and recorded the results below
- [ ] CHANGELOG.md `[Unreleased]` section updated
- [ ] Docs regenerated (`make docs` or `tfplugindocs generate`)
- [ ] Examples in `examples/resources/<name>/` updated if the schema changed
- [ ] Sensitive fields marked with `Sensitive: true`
- [ ] New validators added to schema where applicable
