### PR TITLE
Fix/cloudsync credential computed attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `truenas_cloudsync_credential`'s `provider_attributes_json` was `Required`
+  with no `Computed`, but `mapResponseToModel` always rewrites it from the
+  server's own echo of the credential (the same drift-suppression pattern
+  `truenas_cloud_sync.attributes_json` uses, correctly marked
+  `Optional`+`Computed` there). TrueNAS does not echo every credential field
+  back verbatim - `acc_cloudsync_credential_test.go`'s own
+  `ImportStateVerifyIgnore` rationale already says as much ("cloud-credential
+  attributes contain S3/B2/etc secret keys masked on read") - so any create
+  of an S3 (and likely other) credential fails immediately with "Provider
+  produced inconsistent result after apply: .provider_attributes_json:
+  inconsistent values for sensitive attribute", not a corner case. Changed
+  to `Optional`+`Computed`, matching the sibling field. The same
+  `Required`-without-`Computed` shape exists on `reporting_exporter.go`'s
+  `attributes_json` and `keychain_credential.go`'s `attributes` (both also
+  documented as masked-on-read in the same ignore-list), left out of this
+  fix to keep it scoped to the resource that was actually blocking.
+
 - The `timeouts` block did nothing. All 68 resources declared one, and not a
   single CRUD method read it, so `timeouts { create = "45m" }` was accepted,
   stored in state, and ignored. Reported as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,22 +19,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `truenas_cloudsync_credential`'s `provider_attributes_json` was `Required`
-  with no `Computed`, but `mapResponseToModel` always rewrites it from the
-  server's own echo of the credential (the same drift-suppression pattern
-  `truenas_cloud_sync.attributes_json` uses, correctly marked
-  `Optional`+`Computed` there). TrueNAS does not echo every credential field
-  back verbatim - `acc_cloudsync_credential_test.go`'s own
+- `truenas_cloudsync_credential`'s `mapResponseToModel` always rewrote
+  `provider_attributes_json` from the server's own echo of the credential
+  (the same drift-suppression pattern `cloud_sync.go`/`cloud_backup.go` use
+  for their own, non-sensitive `attributes_json`). TrueNAS masks sensitive
+  fields in that echo - `acc_cloudsync_credential_test.go`'s own
   `ImportStateVerifyIgnore` rationale already says as much ("cloud-credential
-  attributes contain S3/B2/etc secret keys masked on read") - so any create
-  of an S3 (and likely other) credential fails immediately with "Provider
-  produced inconsistent result after apply: .provider_attributes_json:
-  inconsistent values for sensitive attribute", not a corner case. Changed
-  to `Optional`+`Computed`, matching the sibling field. The same
-  `Required`-without-`Computed` shape exists on `reporting_exporter.go`'s
-  `attributes_json` and `keychain_credential.go`'s `attributes` (both also
-  documented as masked-on-read in the same ignore-list), left out of this
-  fix to keep it scoped to the resource that was actually blocking.
+  attributes contain S3/B2/etc secret keys masked on read") - so whenever the
+  planned value for this field was already known (any apply after the
+  upstream access-key/secret-key values it's built from already exist in
+  state, i.e. every apply after the first), `terraform apply` failed
+  outright with "Provider produced inconsistent result after apply:
+  .provider_attributes_json: inconsistent values for sensitive attribute."
+  An initial fix in this same PR marked the field `Optional`+`Computed`
+  (matching `cloud_sync.attributes_json`'s already-correct shape) on the
+  theory that Computed was the missing piece - that didn't hold up: Computed
+  only changes behavior when a field is omitted from config entirely, and
+  this one never is, so the planned value's known-ness (and thus whether the
+  crash fires) never depended on the Required/Optional split. The actual
+  fix is in `mapResponseToModel` itself: it no longer reconstructs
+  `provider_attributes_json` from `cred.Provider` at all, so Create/Update
+  leave it as exactly what was planned and Read/Import leave it as exactly
+  what was already in state - the same "just don't touch it" pattern
+  `user.go` uses for `password` and `iscsi_auth.go` uses for
+  `secret`/`peersecret`. `provider_attributes_json` is back to `Required`
+  (not `Optional`+`Computed`), since nothing about it is actually computed
+  by the provider anymore - `Required` is now the accurate contract. The
+  same `Required`-without-`Computed`-and-reconstructed-from-server shape
+  exists on `reporting_exporter.go`'s `attributes_json` and
+  `keychain_credential.go`'s `attributes` (both also documented as
+  masked-on-read in the same ignore-list), left out of this fix to keep it
+  scoped to the resource that was actually blocking.
 
 - The `timeouts` block did nothing. All 68 resources declared one, and not a
   single CRUD method read it, so `timeouts { create = "45m" }` was accepted,

--- a/docs/resources/cloudsync_credential.md
+++ b/docs/resources/cloudsync_credential.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `name` - (Required) The display name of the credential.
 * `provider_type` - (Required) The cloud provider type. Changing this forces replacement. Valid values: `AZUREBLOB`, `B2`, `BOX`, `DROPBOX`, `FTP`, `GOOGLE_CLOUD_STORAGE`, `GOOGLE_DRIVE`, `GOOGLE_PHOTOS`, `HTTP`, `HUBIC`, `MEGA`, `ONEDRIVE`, `OPENSTACK_SWIFT`, `PCLOUD`, `S3`, `SFTP`, `STORJ_IX`, `WEBDAV`, `YANDEX`.
-* `provider_attributes_json` - (Required) Provider-specific credential fields as a JSON object (e.g. jsonencode({access_key_id = "X", secret_access_key = "Y"})). The exact keys depend on provider_type. Marked sensitive.
+* `provider_attributes_json` - (Optional) Provider-specific credential fields as a JSON object (e.g. jsonencode({access_key_id = "X", secret_access_key = "Y"})). The exact keys depend on provider_type. Optional+Computed rather than Required: mapResponseToModel always rewrites this from the server's own echo of the credential (same drift-suppression pattern as truenas_cloud_sync's attributes_json), and TrueNAS does not necessarily echo every sensitive field back verbatim. A Required-only attribute must come back byte-for-byte identical to the plan or Terraform raises "Provider produced inconsistent result after apply" - Optional+Computed is the contract that actually matches what this resource does. Marked sensitive.
 * `timeouts` - (Optional) Configuration block for operation timeouts. See [below](#timeouts).
 
 ### Timeouts

--- a/docs/resources/cloudsync_credential.md
+++ b/docs/resources/cloudsync_credential.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `name` - (Required) The display name of the credential.
 * `provider_type` - (Required) The cloud provider type. Changing this forces replacement. Valid values: `AZUREBLOB`, `B2`, `BOX`, `DROPBOX`, `FTP`, `GOOGLE_CLOUD_STORAGE`, `GOOGLE_DRIVE`, `GOOGLE_PHOTOS`, `HTTP`, `HUBIC`, `MEGA`, `ONEDRIVE`, `OPENSTACK_SWIFT`, `PCLOUD`, `S3`, `SFTP`, `STORJ_IX`, `WEBDAV`, `YANDEX`.
-* `provider_attributes_json` - (Optional) Provider-specific credential fields as a JSON object (e.g. jsonencode({access_key_id = "X", secret_access_key = "Y"})). The exact keys depend on provider_type. Optional+Computed rather than Required: mapResponseToModel always rewrites this from the server's own echo of the credential (same drift-suppression pattern as truenas_cloud_sync's attributes_json), and TrueNAS does not necessarily echo every sensitive field back verbatim. A Required-only attribute must come back byte-for-byte identical to the plan or Terraform raises "Provider produced inconsistent result after apply" - Optional+Computed is the contract that actually matches what this resource does. Marked sensitive.
+* `provider_attributes_json` - (Required) Provider-specific credential fields as a JSON object (e.g. jsonencode({access_key_id = "X", secret_access_key = "Y"})). The exact keys depend on provider_type. Write-only in practice: TrueNAS masks sensitive fields (e.g. secret_access_key) in its own echo of the credential, so this attribute is never reconstructed from the server response the way truenas_cloud_sync's attributes_json is - it stays exactly what was planned. Marked sensitive.
 * `timeouts` - (Optional) Configuration block for operation timeouts. See [below](#timeouts).
 
 ### Timeouts

--- a/internal/provider/requires_replace_invariant_test.go
+++ b/internal/provider/requires_replace_invariant_test.go
@@ -135,9 +135,10 @@ func TestOptionalComputedHasUseStateForUnknown(t *testing.T) {
 	// for state migration. Most attributes should NOT be in here, the
 	// default behavior is to preserve state when config is null.
 	exclusions := map[string]string{
-		"cronjob.go:description":         "appears in cronjobSchemaV0, the frozen v0 schema used by UpgradeState, historical shape must not be modified or state migration breaks",
-		"system_update.go:auto_download": "appears only in systemUpdateSchemaV0, the frozen v0 schema used by UpgradeState; renamed to autocheck in v1 and the historical shape must not be modified",
-		"system_update.go:train":         "appears only in systemUpdateSchemaV0, the frozen v0 schema used by UpgradeState; trains were replaced by profiles in TrueNAS 26.0 and the historical shape must not be modified",
+		"cronjob.go:description":                           "appears in cronjobSchemaV0, the frozen v0 schema used by UpgradeState, historical shape must not be modified or state migration breaks",
+		"system_update.go:auto_download":                   "appears only in systemUpdateSchemaV0, the frozen v0 schema used by UpgradeState; renamed to autocheck in v1 and the historical shape must not be modified",
+		"system_update.go:train":                           "appears only in systemUpdateSchemaV0, the frozen v0 schema used by UpgradeState; trains were replaced by profiles in TrueNAS 26.0 and the historical shape must not be modified",
+		"cloudsync_credential.go:provider_attributes_json": "computed-at-apply secret: TrueNAS masks sensitive credential fields (e.g. secret_access_key) on read, so mapResponseToModel's server echo can legitimately differ from the plan value on every apply - UseStateForUnknown would paper over that by pinning stale state instead of surfacing it. Same masked-on-read behavior documented for reporting_exporter.go's attributes_json and keychain_credential.go's attributes in allowedIgnoreFields (importstate_verify_ignore_invariant_test.go), though both are still Required-only today so this test doesn't see them yet.",
 	}
 
 	matches, err := filepath.Glob("../resources/*.go")

--- a/internal/provider/requires_replace_invariant_test.go
+++ b/internal/provider/requires_replace_invariant_test.go
@@ -135,10 +135,9 @@ func TestOptionalComputedHasUseStateForUnknown(t *testing.T) {
 	// for state migration. Most attributes should NOT be in here, the
 	// default behavior is to preserve state when config is null.
 	exclusions := map[string]string{
-		"cronjob.go:description":                           "appears in cronjobSchemaV0, the frozen v0 schema used by UpgradeState, historical shape must not be modified or state migration breaks",
-		"system_update.go:auto_download":                   "appears only in systemUpdateSchemaV0, the frozen v0 schema used by UpgradeState; renamed to autocheck in v1 and the historical shape must not be modified",
-		"system_update.go:train":                           "appears only in systemUpdateSchemaV0, the frozen v0 schema used by UpgradeState; trains were replaced by profiles in TrueNAS 26.0 and the historical shape must not be modified",
-		"cloudsync_credential.go:provider_attributes_json": "computed-at-apply secret: TrueNAS masks sensitive credential fields (e.g. secret_access_key) on read, so mapResponseToModel's server echo can legitimately differ from the plan value on every apply - UseStateForUnknown would paper over that by pinning stale state instead of surfacing it. Same masked-on-read behavior documented for reporting_exporter.go's attributes_json and keychain_credential.go's attributes in allowedIgnoreFields (importstate_verify_ignore_invariant_test.go), though both are still Required-only today so this test doesn't see them yet.",
+		"cronjob.go:description":         "appears in cronjobSchemaV0, the frozen v0 schema used by UpgradeState, historical shape must not be modified or state migration breaks",
+		"system_update.go:auto_download": "appears only in systemUpdateSchemaV0, the frozen v0 schema used by UpgradeState; renamed to autocheck in v1 and the historical shape must not be modified",
+		"system_update.go:train":         "appears only in systemUpdateSchemaV0, the frozen v0 schema used by UpgradeState; trains were replaced by profiles in TrueNAS 26.0 and the historical shape must not be modified",
 	}
 
 	matches, err := filepath.Glob("../resources/*.go")

--- a/internal/resources/cloudsync_credential.go
+++ b/internal/resources/cloudsync_credential.go
@@ -118,8 +118,16 @@ func (r *CloudSyncCredentialResource) Schema(ctx context.Context, _ resource.Sch
 			"provider_attributes_json": schema.StringAttribute{
 				Description: "Provider-specific credential fields as a JSON object " +
 					"(e.g. jsonencode({access_key_id = \"X\", secret_access_key = \"Y\"})). " +
-					"The exact keys depend on provider_type.",
-				Required:  true,
+					"The exact keys depend on provider_type. Optional+Computed rather than " +
+					"Required: mapResponseToModel below always rewrites this from the server's " +
+					"own echo of the credential (same drift-suppression pattern as " +
+					"truenas_cloud_sync's attributes_json), and TrueNAS does not necessarily " +
+					"echo every sensitive field back verbatim (see CHANGELOG). A Required-only " +
+					"attribute must come back byte-for-byte identical to the plan or Terraform " +
+					"raises \"Provider produced inconsistent result after apply\" - Optional+Computed " +
+					"is the contract that actually matches what this resource does.",
+				Optional:  true,
+				Computed:  true,
 				Sensitive: true,
 			},
 		},

--- a/internal/resources/cloudsync_credential.go
+++ b/internal/resources/cloudsync_credential.go
@@ -10,9 +10,10 @@
 //   - Users pass e.g.
 //     `provider_attributes_json = jsonencode({ access_key_id = "X",
 //     secret_access_key = "Y" })`.
-//   - On read we filter the server response back down to the keys the user
-//     originally specified (via filterJSONByKeys) so server-side defaults
-//     don't cause phantom drift, same pattern as cloud_backup.go.
+//   - The field is write-only from the API's perspective: TrueNAS masks
+//     sensitive values (e.g. secret_access_key) in its own echo of the
+//     credential, so mapResponseToModel never reconstructs it from the
+//     server response, unlike cloud_backup.go's attributes_json.
 package resources
 
 import (

--- a/internal/resources/cloudsync_credential.go
+++ b/internal/resources/cloudsync_credential.go
@@ -118,16 +118,16 @@ func (r *CloudSyncCredentialResource) Schema(ctx context.Context, _ resource.Sch
 			"provider_attributes_json": schema.StringAttribute{
 				Description: "Provider-specific credential fields as a JSON object " +
 					"(e.g. jsonencode({access_key_id = \"X\", secret_access_key = \"Y\"})). " +
-					"The exact keys depend on provider_type. Optional+Computed rather than " +
-					"Required: mapResponseToModel below always rewrites this from the server's " +
-					"own echo of the credential (same drift-suppression pattern as " +
-					"truenas_cloud_sync's attributes_json), and TrueNAS does not necessarily " +
-					"echo every sensitive field back verbatim (see CHANGELOG). A Required-only " +
-					"attribute must come back byte-for-byte identical to the plan or Terraform " +
-					"raises \"Provider produced inconsistent result after apply\" - Optional+Computed " +
-					"is the contract that actually matches what this resource does.",
-				Optional:  true,
-				Computed:  true,
+					"The exact keys depend on provider_type. Write-only in practice: TrueNAS " +
+					"masks sensitive fields (e.g. secret_access_key) in its own echo of the " +
+					"credential, so mapResponseToModel below never reconstructs this attribute " +
+					"from the server response the way cloud_sync.go/cloud_backup.go do for " +
+					"their own (non-sensitive) attributes_json - it stays exactly what was " +
+					"planned. Required, not Optional+Computed: nothing about it is actually " +
+					"computed by the provider, so Required is the honest contract, and it also " +
+					"avoids TestOptionalComputedHasUseStateForUnknown's UseStateForUnknown/Default " +
+					"requirement for a field that has neither.",
+				Required:  true,
 				Sensitive: true,
 			},
 		},
@@ -344,38 +344,30 @@ func (r *CloudSyncCredentialResource) ImportState(ctx context.Context, req resou
 }
 
 // mapResponseToModel projects a CloudSyncCredential API response into the
-// Terraform model, extracting the provider type and filtering the remaining
-// provider keys back down to the user's original JSON shape to avoid
-// phantom drift from server-side defaults.
+// Terraform model, extracting the provider type. Deliberately does NOT
+// touch model.ProviderAttributesJSON: TrueNAS masks sensitive credential
+// fields (e.g. secret_access_key) in its own echo of the credential, so
+// reconstructing that attribute from cred.Provider (as this function used
+// to, via filterJSONByKeys/normalizeJSON - the same drift-suppression
+// pattern cloud_sync.go and cloud_backup.go use for their own,
+// non-sensitive attributes_json) can silently produce a value that
+// differs from what was actually planned. When the plan's value for that
+// field is already known (not depending on an as-yet-unapplied resource),
+// Terraform requires the post-apply value to match it byte-for-byte or
+// apply fails outright with "Provider produced inconsistent result after
+// apply" - a hard crash on every Create/Update, not just a cosmetic
+// diff. Leaving the field alone means Create/Update keep exactly what
+// was planned (model IS the plan there) and Read/Import keep exactly
+// what was already in state - this resource treats
+// provider_attributes_json as write-only from the API's perspective,
+// the same way user.go treats `password` and iscsi_auth.go treats
+// `secret`/`peersecret` (see those resources' own ImportStateVerifyIgnore
+// entries in importstate_verify_ignore_invariant_test.go).
 func (r *CloudSyncCredentialResource) mapResponseToModel(_ context.Context, cred *truenas.CloudSyncCredential, model *CloudSyncCredentialResourceModel) {
 	model.ID = types.StringValue(strconv.Itoa(cred.ID))
 	model.Name = types.StringValue(cred.Name)
 
-	// Split out the `type` key: it maps to provider_type, everything else
-	// becomes provider_attributes_json.
-	providerType := ""
-	remaining := make(map[string]interface{}, len(cred.Provider))
-	for k, v := range cred.Provider {
-		if k == "type" {
-			if s, ok := v.(string); ok {
-				providerType = s
-			}
-			continue
-		}
-		remaining[k] = v
-	}
-	if providerType != "" {
+	if providerType, ok := cred.Provider["type"].(string); ok && providerType != "" {
 		model.ProviderType = types.StringValue(providerType)
 	}
-
-	// json.Marshal cannot fail: `remaining` was built from a decoded JSON map.
-	raw, _ := json.Marshal(remaining)
-
-	// Filter server response against prior user-supplied JSON to avoid
-	// server-side defaults (e.g. region = null, endpoint = "") causing drift.
-	// Both helpers operate on known-valid JSON from json.Marshal above.
-	prior := model.ProviderAttributesJSON.ValueString()
-	filtered, _ := filterJSONByKeys(string(raw), prior)
-	canon, _ := normalizeJSON(filtered)
-	model.ProviderAttributesJSON = types.StringValue(string(canon))
 }


### PR DESCRIPTION
Feel free to ignore this if you're not happy with it - I'll admit it's 100% Claude generated, and I don't fully understand the purpose of computing the credential attribute in the first place (I'm guessing it was there for a reason?).

Bottom line is - this wasn't working in my deployment, and this patch fixes it.

Thanks for your work putting this together! :)

Richard

> Claude's notes follow ...

## Summary
`truenas_cloudsync_credential`'s `mapResponseToModel` always reconstructed
`provider_attributes_json` from the server's own echo of the credential (the
same drift-suppression pattern `cloud_sync.go`/`cloud_backup.go` use for
their own, non-sensitive `attributes_json`). TrueNAS masks sensitive fields
in that echo - this file's own `acc_cloudsync_credential_test.go` already
documents `provider_attributes_json` as masked-on-read in
`importstate_verify_ignore_invariant_test.go`'s `allowedIgnoreFields`. Once
the plan's value for that field was already known (any apply after the
access_key_id/secret_access_key values it's built from already exist in
state), `terraform apply` failed outright with `Provider produced
inconsistent result after apply: .provider_attributes_json: inconsistent
values for sensitive attribute`. Fixed by no longer reconstructing that
attribute from the server response at all - it now stays exactly what was
planned (Create/Update) or exactly what was already in state (Read/Import),
the same "just don't touch it" pattern `user.go` uses for `password` and
`iscsi_auth.go` uses for `secret`/`peersecret`.

(This PR went through an earlier, incomplete attempt - marking the field
`Optional`+`Computed` on the theory that `Computed` was the missing piece.
That didn't hold up under a real apply: `Computed` only changes behavior
when a field is omitted from config entirely, and this one never is, so
the plan's known-ness - and thus whether the crash fires - never actually
depended on the `Required`/`Optional` split. Mentioning it here in case it
saves a reviewer from going down the same path.)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New resource (new `truenas_*` resource)
- [ ] New data source (new `data.truenas_*` data source)
- [ ] Enhancement to an existing resource/data source
- [ ] Provider-level change (client, retry, timeouts, schema)
- [ ] Documentation only
- [ ] CI / tooling / build
- [ ] Breaking change (requires major version bump)

## Resources / data sources affected
- `truenas_cloudsync_credential`

## Checklist
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `go test -cover ./...` maintains 100.0% on every package
- [x] `golangci-lint run ./...` passes with zero findings
- [x] `govulncheck ./...` reports no new vulnerabilities
- [x] `tfplugindocs validate` passes
- [ ] I ran the relevant `TF_ACC` acceptance tests against a real TrueNAS SCALE
      test VM (not prod) and recorded the results below
      <!-- NOT run - see note below -->
- [x] CHANGELOG.md `[Unreleased]` section updated
- [x] Docs regenerated (`make docs` or `tfplugindocs generate`)
      <!-- hand-edited + `tfplugindocs validate`d, not regenerated via `make docs-regen` -
      that target is flagged DANGEROUS/strips custom prose, and this is a one-line
      Required/Optional wording fix, not a schema-wide rename -->
- [ ] Examples in `examples/resources/<name>/` updated if the schema changed
      <!-- N/A - the schema's final shape (Required) is what the existing S3/B2
      examples already assume; no example needed a change -->
- [x] Sensitive fields marked with `Sensitive: true`
- [ ] New validators added to schema where applicable
      <!-- N/A - no new validation logic -->

## Acceptance test results

```
N/A - not run against a live TrueNAS SCALE test VM (didn't have one on hand
for this pass). Verified instead against a real TrueNAS SCALE 25.10.4
instance via a downstream Terraform config (private repo) that:
  - reliably hit this exact crash on `tofu apply` before the fix
  - also hit it again after the *first* (Optional+Computed-only) attempt,
    once the fields it's built from were already known - confirming that
    attempt was insufficient
  - applies cleanly, with the credential correctly created and usable by a
    dependent truenas_cloud_sync resource, with this branch's final commit
Happy to run the acceptance triad against a real TF_ACC test VM if that's
wanted before merge.
```

## Breaking change notice
N/A - not a breaking change. Existing configs that always set
`provider_attributes_json` (the only way to use this resource meaningfully)
are unaffected.

## Related issues
None filed yet - happy to open one first if you'd rather have an issue to
reference, just went straight to a PR since the root cause was already
fully diagnosed (including live-reproducing it) before opening this.

---

**Note on scope**: `reporting_exporter.go`'s `attributes_json` and
`keychain_credential.go`'s `attributes` have the identical
reconstructed-from-server-response shape, and both are *also* documented as
masked-on-read in the same `allowedIgnoreFields` map
(`acc_reporting_exporter_test.go::attributes_json`,
`acc_keychain_credential_test.go::attributes`) - meaning they likely have
the same latent crash, just not yet hit in practice (unlike this one, which
was confirmed live). Deliberately left out of this PR to keep it scoped to
the resource that was actually blocking; happy to follow up with those in a
separate PR if wanted.
